### PR TITLE
Speculative .raku() implementation supporting sparseness

### DIFF
--- a/lib/Array/Sparse.pm6
+++ b/lib/Array/Sparse.pm6
@@ -135,40 +135,32 @@ role Array::Sparse:ver<0.0.6>:auth<cpan:ELIZABETH>
     }
 
     method raku(::?ROLE:D:) {
-        my @chunks; # contiguous ranges of existing values
-        my $last_i; # faster to type and execute than @chunks[*-1].key[1]
+        return '(my @ is ' ~ ::?ROLE.^name ~ ')' unless %!sparse;
 
-        for %!sparse.pairs.sort(*.key) {
-            if $last_i.defined && .key == $last_i + 1 {
-                # append to last chunk
-                @chunks[*-1].value.push: .value;
-                @chunks[*-1].key[1]++;
-            } else {
-                # push new chunk
-                # key is a 2-element Array instead of a Range for mutability
-                push @chunks, [.key, .key] => [.value];
-            }
-            $last_i = .key;
-        }
+        my $chunk_start; # beginning of the current contiguous range
+        my $last_i; # previous iteration's index
+        my $indices; # LHS slice
+        my $values = ''; # RHS list
 
-        my $raku = 'do { (my @a is ' ~ ::?ROLE.^name ~ ')[';
-        for @chunks».key { # build indices
-            if .[0] == .[1] {
-                $raku ~= .[0] ~ ', ';
-            } else {
-                $raku ~= .[0] ~ '..' ~ .[1] ~ ', ' ;
+        for self.keys {
+            if !$last_i.defined { # first iteration
+                $indices = ~$_;
+                $chunk_start = $_;
+            } elsif $_ != $last_i + 1 { # beginning of new chunk
+                if $chunk_start === $last_i { # following single-element chunk
+                    $indices ~= ", $_";
+                } else { # following multi-element chunk
+                    $indices ~= "..$last_i, $_";
+                }
+                $chunk_start = $_;
             }
+            $values ~= "%!sparse.AT-KEY($_).raku(), ";
+            $last_i = $_;
         }
-        $raku .= chop: 2;
-        $raku ~= '] = ';
-        for @chunks».value { # build values
-            for @$_ {
-                $raku ~= $_.raku ~ ', ';
-            }
-        }
-        $raku .= chop: 2;
-        $raku ~= '; @a; }';
-        $raku;
+        $indices ~= "..$last_i" if $last_i != $chunk_start; # close final chunk
+
+        'do { (my @a is ' ~ ::?ROLE.^name ~ ')[' ~ $indices ~ '] = ' ~
+            $values.chop(2) ~ '; @a; }';
     }
 
 #---- Our own private methods --------------------------------------------------

--- a/lib/Array/Sparse.pm6
+++ b/lib/Array/Sparse.pm6
@@ -135,7 +135,7 @@ role Array::Sparse:ver<0.0.6>:auth<cpan:ELIZABETH>
     }
 
     method raku(::?ROLE:D:) {
-        return '(my @ is ' ~ ::?ROLE.^name ~ ')' unless %!sparse;
+        return self.Array::Agnostic::raku if %!sparse == $!end + 1; # solid
 
         my $chunk_start;                        # beginning of contiguous chunk
         my $last_i;                             # previous iteration's index
@@ -147,26 +147,26 @@ role Array::Sparse:ver<0.0.6>:auth<cpan:ELIZABETH>
                 $indices = ~$_;
                 $chunk_start = $_;
             } elsif $_ != $last_i + 1 {             # beginning of next chunk
-                if $chunk_start == $last_i {            # after 1-element chunk
-                    $indices ~= ", $_";
-                } elsif $chunk_start == $last_i - 1 {   # after 2-element chunk
-                    $indices ~= ", $last_i, $_";
-                } else {                                # after >2-element chunk
-                    $indices ~= "..$last_i, $_";
+                if $chunk_start == $last_i {            # after 1 element chunk
+                    $indices ~= ",$_";
+                } elsif $chunk_start == $last_i - 1 {   # after 2 element chunk
+                    $indices ~= ",$last_i,$_";
+                } else {                                # after 3+ element chunk
+                    $indices ~= "..$last_i,$_";
                 }
                 $chunk_start = $_;
             }
-            $values ~= "%!sparse.AT-KEY($_).raku(), ";
+            $values ~= "%!sparse.AT-KEY($_).raku(),";
             $last_i = $_;
         }
-        if $chunk_start == $last_i - 1 {        # close final 2-element chunk
-            $indices ~= ", $last_i";
-        } elsif $chunk_start != $last_i {       # close final >2-element chunk
+        if $chunk_start == $last_i - 1 {        # close final 2 element chunk
+            $indices ~= ",$last_i";
+        } elsif $chunk_start != $last_i {       # close final 3+ element chunk
             $indices ~= "..$last_i";
         }
 
-        'do { (my @a is ' ~ ::?ROLE.^name ~ ')[' ~ $indices ~ '] = ' ~
-            $values.chop(2) ~ '; @a; }';
+        'do {(my \a := ' ~ ::?ROLE.^name ~ '.new)[' ~ $indices ~ '] = ' ~
+            $values.chop ~ '; a; }';
     }
 
 #---- Our own private methods --------------------------------------------------


### PR DESCRIPTION
I'm not sure if this is how you want to fix #2, but it does round-trip with EVAL properly. I largely did it to amuse myself, so it won't hurt my feelings if you close this without merging. I understand it's a rather inelegant solution.